### PR TITLE
fix to terminate ffmpeg when playback stops

### DIFF
--- a/lib/streams/internal_proxy.py
+++ b/lib/streams/internal_proxy.py
@@ -84,7 +84,7 @@ class InternalProxy(Stream):
                 self.in_queue.get()
         except (Empty, EOFError):
             pass
-        self.in_queue.put({'uri': 'terminate'})
+        self.in_queue.put({'uri_dt': 'terminate'})
         time.sleep(0.2)
         self.t_m3u8.terminate()
         self.t_m3u8.join()


### PR DESCRIPTION
ffmpeg processes were being left behind as zombie processes. This fix is to stop that.