### PR TITLE
Changed ' to ", to fix m3u/m3u8 list specific to Jellyfin loading m3u…

### DIFF
--- a/lib/clients/channels/channels.py
+++ b/lib/clients/channels/channels.py
@@ -124,14 +124,14 @@ def get_channels_m3u(_config, _base_url, _namespace, _instance, _plugins):
             fakefile.write(
                 '%s\n' % (
                         record_marker + ':-1' + ' ' +
-                        'channelID=\'' + sid + '\' ' +
-                        'tvg-num=\'' + updated_chnum + '\' ' +
-                        'tvg-chno=\'' + updated_chnum + '\' ' +
-                        'tvg-name=\'' + sid_data['display_name'] + '\' ' +
-                        'tvg-id=\'' + sid + '\' ' +
-                        (('tvg-logo=\'' + sid_data['thumbnail'] + '\' ')
+                        'channel-id="' + sid + '" ' +
+                        'tvg-num="' + updated_chnum + '" ' +
+                        'tvg-chno="' + updated_chnum + '" ' +
+                        'tvg-name="' + sid_data['display_name'] + '" ' +
+                        'tvg-id="' + sid + '" ' +
+                        (('tvg-logo="' + sid_data['thumbnail'] + '" ')
                          if sid_data['thumbnail'] else '') +
-                        'group-title=\'' + groups + '\',' + service_name
+                        'group-title="' + groups + '", ' + service_name
                 )
             )
             fakefile.write(

--- a/lib/clients/channels/channels.py
+++ b/lib/clients/channels/channels.py
@@ -124,7 +124,7 @@ def get_channels_m3u(_config, _base_url, _namespace, _instance, _plugins):
             fakefile.write(
                 '%s\n' % (
                         record_marker + ':-1' + ' ' +
-                        'channelID="' + sid + '" ' +
+                        'channel-id="' + sid + '" ' +
                         'tvg-num="' + updated_chnum + '" ' +
                         'tvg-chno="' + updated_chnum + '" ' +
                         'tvg-name="' + sid_data['display_name'] + '" ' +

--- a/lib/clients/channels/channels.py
+++ b/lib/clients/channels/channels.py
@@ -124,7 +124,7 @@ def get_channels_m3u(_config, _base_url, _namespace, _instance, _plugins):
             fakefile.write(
                 '%s\n' % (
                         record_marker + ':-1' + ' ' +
-                        'channel-id="' + sid + '" ' +
+                        'channelID="' + sid + '" ' +
                         'tvg-num="' + updated_chnum + '" ' +
                         'tvg-chno="' + updated_chnum + '" ' +
                         'tvg-name="' + sid_data['display_name'] + '" ' +


### PR DESCRIPTION
… lists.

For some odd reason Jellyfin doesn't like ' around data it prefers ".  Also changed channelID to channel-id.  I see this more commonly and it also uses that id in the epg/xmltv files.

This should help deal with guide data and loading icons for channels without going in an actually mapping channels in Jellyfin.