### PR TITLE
Add lcn tag for better matching in Plex

### DIFF
--- a/lib/clients/epg2xml.py
+++ b/lib/clients/epg2xml.py
@@ -211,7 +211,8 @@ class EPG:
                 EPG.sub_el(c_out, 'display-name', _text=ch_data['json']['callsign'])
                 EPG.sub_el(c_out, 'display-name', _text='%s %s' %
                                                         (updated_chnum, ch_data['json']['callsign']))
-
+                EPG.sub_el(c_out, 'lcn', _text='%s' %
+                                                        (updated_chnum))
                 if self.config['epg']['epg_channel_icon'] and ch_data['thumbnail'] is not None:
                     EPG.sub_el(c_out, 'icon', src=ch_data['thumbnail'])
                 break


### PR DESCRIPTION
Plex (and possibly other clients) use the LCN tag as the channel number, which is a more elegant way than using the option "Use Channel # for Channel ID".

The simple patch results in something like below:
```
<channel id="371">
<display-name>1404 MTV USA</display-name>
<display-name>MTV USA</display-name>
<display-name>MTV-E</display-name>
<display-name>1404 MTV-E</display-name>
<lcn>1404</lcn>
</channel>
```
A further advantage of this is that you would not need to create multiple display-name tags with the channel number.  You could also redo the channel id tags so there would be no chance of having multiple channels with the same number (which I have seen between plugins).  An idea would be for the channel-id tags to include the namespace and then the channel number or channel name.