### PR TITLE
Add accept-language header

### DIFF
--- a/lib/plugins/plugin_channels.py
+++ b/lib/plugins/plugin_channels.py
@@ -85,6 +85,7 @@ class PluginChannels:
     def get_uri_json_data(self, _uri, _retries):
         header = {
             'Content-Type': 'application/json',
+            'Accept-Language': 'en-US',
             'User-agent': utils.DEFAULT_USER_AGENT}
         resp = self.plugin_obj.http_session.get(_uri, headers=header, timeout=8)
         x = resp.json()

--- a/lib/plugins/plugin_channels.py
+++ b/lib/plugins/plugin_channels.py
@@ -96,6 +96,7 @@ class PluginChannels:
     def get_uri_data(self, _uri, _retries, _header=None, _data=None, _cookies=None):
         if _header is None:
             header = {
+                'Accept-Language': 'en-US',
                 'User-agent': utils.DEFAULT_USER_AGENT}
         else:
             header = _header

--- a/lib/plugins/plugin_epg.py
+++ b/lib/plugins/plugin_epg.py
@@ -62,7 +62,10 @@ class PluginEPG:
     @handle_json_except
     def get_uri_data(self, _uri, _retries, _header=None):
         if _header is None:
-            header = {'User-agent': utils.DEFAULT_USER_AGENT}
+            header = {
+                'User-agent': utils.DEFAULT_USER_AGENT,
+                'Accept-Language': 'en-US'
+            }
         else:
             header = _header
         resp = self.plugin_obj.http_session.get(_uri, headers=header, timeout=8)

--- a/lib/plugins/plugin_programs.py
+++ b/lib/plugins/plugin_programs.py
@@ -57,7 +57,10 @@ class PluginPrograms:
     @handle_json_except
     def get_uri_data(self, _uri, _retries, _header=None):
         if _header is None:
-            header = {'User-agent': utils.DEFAULT_USER_AGENT}
+            header = {
+                'User-agent': utils.DEFAULT_USER_AGENT,
+                'Accept-Language': 'en-US'
+            }
         else:
             header = _header
         resp = self.plugin_obj.http_session.get(_uri, headers=header, timeout=8)


### PR DESCRIPTION
Fixes #254. 

TVGuide returns an empty string when not using the `Accept-Language` header, unless the underlying API was called in a browser, at which point data gets returned normally. If the `Accept-Language` header is specified, this does not occur.